### PR TITLE
Switch to MIT license, add composer.json

### DIFF
--- a/INSTALL.TXT
+++ b/INSTALL.TXT
@@ -1,7 +1,0 @@
-# Installation Instructions
-
-1. Unzip this file in your site's packages/ directory.
-2. Login to your site as an administrator.
-3. Find the "Add Functionality" page in your dashboard.
-4. Find this package in the list of packages awaiting installation.
-5. Click the "install" button.

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,1 +1,21 @@
-This software is licensed under the terms described in the Concrete CMS marketplace. Please find the add-on there for the latest license copy.
+MIT License
+
+Copyright (c) 2023 Fumito Mizuno
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "ounziw/ounziw_osm",
+    "description": "Concrete package to display maps using OpenStreetMap",
+    "type": "concrete5-package",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fumito Mizuno"
+        }
+    ],
+    "minimum-stability": "stable",
+    "homepage": "https://github.com/ounziw/Free-Map",
+    "keywords": [
+        "concrete",
+        "cms",
+        "concrete5",
+        "map",
+        "openstreetmap",
+        "osm",
+        "free"
+    ],
+    "support": {
+        "source": "https://github.com/ounziw/Free-Map",
+        "issues": "https://github.com/ounziw/Free-Map/issues"
+    }
+}


### PR DESCRIPTION
The INSTALL.TXT and LICENSE.TXT files come from the package downloaded from the ConcreteCMS marketplace, isn't it?

What about:
- adding a `composer.json` file, so that this package can be installed via composer (and it would be great if you could add this repository to [packagist](https://packagist.org/))
- removing INSTALL.TXT from the repository, because people may install it in other ways (for example with composer). In any way, if people downloads the package from the ConcreteCMS marketplace, they will have it again (since the ConcreteCMS marketplace adds it automatically to the zip files downloaded from there)
- switching from the ConcreteCMS Marketplace License to the MIT license because:
  - people may not know the ConcreteCMS Marketplace License (and there's no easy way to find it)
  - the LICENSE.TXT file tells user to look for the license of the package in the ConcreteCMS marketplace, and [there people read that it's MIT](https://marketplace.concretecms.com/marketplace/addons/free-map)