### PR TITLE
Fix localizable string for invalid zoom, simplify error strings.

### DIFF
--- a/blocks/ounziw_osm_map/controller.php
+++ b/blocks/ounziw_osm_map/controller.php
@@ -302,20 +302,20 @@ class Controller extends BlockController
             }
         }
         if ($result['latitude'] === null) {
-            $errors->add(t('The latitude must be a floating number.'));
+            $errors->add(t('The latitude must be a number.'));
         }
         if ($result['longitude'] === null) {
-            $errors->add(t('The longitude must be a floating number.'));
+            $errors->add(t('The longitude must be a number.'));
         }
         if ($result['zoom'] === null || $result['zoom'] < static::ZOOM_MIN || $result['zoom'] > static::ZOOM_MAX) {
-            $errors->add(t('The zoom level must be a number between %1%s and %2$s.', self::ZOOM_MIN, self::ZOOM_MAX));
+            $errors->add(t('The zoom level must be a number between %1$s and %2$s.', self::ZOOM_MIN, self::ZOOM_MAX));
         }
         if ($result['marker'] === 1) {
             if ($result['markerlatitude'] === null) {
-                $errors->add(t('The marker latitude must be a floating number.'));
+                $errors->add(t('The marker latitude must be a number.'));
             }
             if ($result['markerlongitude'] === null) {
-                $errors->add(t('The marker longitude must be a floating number.'));
+                $errors->add(t('The marker longitude must be a number.'));
             }
         }
 


### PR DESCRIPTION
I made a mistake in the "invalid zoom" error message: `%1%s` must be `%1$s`.

Also, I don't think that "floating number" is correct. We should write "floating point number" or even better simply "number".